### PR TITLE
Capability to generate AWS credentials for STS path

### DIFF
--- a/.changeset/fluffy-bees-glow.md
+++ b/.changeset/fluffy-bees-glow.md
@@ -1,0 +1,5 @@
+---
+"@litehex/node-vault": patch
+---
+
+feat: Capability to generate AWS credentials for STS path

--- a/src/engine/aws.ts
+++ b/src/engine/aws.ts
@@ -191,7 +191,7 @@ export class Aws extends ApiSector {
   }
 
   /**
-   * Generate credentials
+   * Generate credentials for the path `/aws/creds/:name`
    *
    * @link https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials
    */
@@ -202,7 +202,8 @@ export class Aws extends ApiSector {
       client: this.client,
       schema: {
         path: z.object({
-          name: z.string()
+          name: z.string(),
+          isSTS: z.boolean().optional()
         }),
         searchParams: z.object({
           role_arn: z.string().optional(),
@@ -214,6 +215,32 @@ export class Aws extends ApiSector {
       }
     });
   }
+
+    /**
+   * Generate credentials for the path `/aws/sts/:name`
+   *
+   * @link https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials
+   */
+    get stsCredentials() {
+      return generateCommand({
+        method: 'POST',
+        path: '/aws/sts/{{name}}',
+        client: this.client,
+        schema: {
+          path: z.object({
+            name: z.string(),
+            isSTS: z.boolean().optional()
+          }),
+          searchParams: z.object({
+            role_arn: z.string().optional(),
+            role_session_name: z.string().optional(),
+            ttl: z.string().optional(),
+            mfa_code: z.string().optional()
+          }),
+          response: z.any()
+        }
+      });
+    }
 
   /**
    * Create/Update static role

--- a/src/engine/aws.ts
+++ b/src/engine/aws.ts
@@ -216,31 +216,31 @@ export class Aws extends ApiSector {
     });
   }
 
-    /**
+  /**
    * Generate credentials for the path `/aws/sts/:name`
    *
    * @link https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials
    */
-    get stsCredentials() {
-      return generateCommand({
-        method: 'POST',
-        path: '/aws/sts/{{name}}',
-        client: this.client,
-        schema: {
-          path: z.object({
-            name: z.string(),
-            isSTS: z.boolean().optional()
-          }),
-          searchParams: z.object({
-            role_arn: z.string().optional(),
-            role_session_name: z.string().optional(),
-            ttl: z.string().optional(),
-            mfa_code: z.string().optional()
-          }),
-          response: z.any()
-        }
-      });
-    }
+  get stsCredentials() {
+    return generateCommand({
+      method: 'POST',
+      path: '/aws/sts/{{name}}',
+      client: this.client,
+      schema: {
+        path: z.object({
+          name: z.string(),
+          isSTS: z.boolean().optional()
+        }),
+        searchParams: z.object({
+          role_arn: z.string().optional(),
+          role_session_name: z.string().optional(),
+          ttl: z.string().optional(),
+          mfa_code: z.string().optional()
+        }),
+        response: z.any()
+      }
+    });
+  }
 
   /**
    * Create/Update static role


### PR DESCRIPTION
Implement the AWS credential generation for path `/aws/sts/:name` and method `POST` as described in [hashicorp documentation here](https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials)