### PR TITLE
fix: pass fetcher through so that it can be used

### DIFF
--- a/.changeset/slow-paws-melt.md
+++ b/.changeset/slow-paws-melt.md
@@ -1,0 +1,5 @@
+---
+"@litehex/node-vault": patch
+---
+
+fix: the `fetcher` parameter was not being assigned to the client

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -10,7 +10,7 @@ import {
   SuccessResponseSchema,
   ZodAnyRecord
 } from '@/schema';
-import { ClientOptions } from '@/typings';
+import { ClientOptions, Fetcher } from '@/typings';
 import { generateCommand } from '@litehex/node-vault';
 import type { RequestInit } from 'undici';
 import { z } from 'zod';
@@ -22,9 +22,10 @@ class Client {
   namespace: string | undefined;
   token: string | undefined;
   request: Partial<Omit<RequestInit, 'url'>> | undefined;
+  fetcher: Fetcher | undefined;
 
   constructor(protected opts: ClientOptions = {}) {
-    const { request, ...restOpts } = opts;
+    const { request, fetcher, ...restOpts } = opts;
     const options = ClientOptionsSchema.parse(restOpts);
 
     this.endpoint = options.endpoint || process.env.VAULT_ADDR || 'http://127.0.0.1:8200';
@@ -33,6 +34,7 @@ class Client {
     this.namespace = options.namespace || process.env.VAULT_NAMESPACE;
     this.token = options.token || process.env.VAULT_TOKEN;
 
+    this.fetcher = fetcher;
     this.request = request;
   }
 


### PR DESCRIPTION
## Description
This declares `fetcher` on the client and actually passes it through so that it can end up being used by `generateCommand()` if it is set.