### PR TITLE
fix: using the environment's global `fetch` API instead of `undici`.

### DIFF
--- a/.changeset/metal-games-beam.md
+++ b/.changeset/metal-games-beam.md
@@ -1,0 +1,7 @@
+---
+'@litehex/node-vault': major
+---
+
+Fix: Using the environment's global `fetch` API instead of `undici`.
+
+This change makes this library more compatible with JavaScript runtimes that do not support `Node.js` modules. If you want to use `undici` again,  use the [Custom Fetcher](https://github.com/shahradelahi/node-vault/wiki/Usage#custom-fetcher) feature.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "packageManager": "pnpm@8.15.7",
   "dependencies": {
     "p-safe": "^1.0.0",
-    "undici": "^6.19.2",
     "zod": "^3.23.8",
     "zod-request": "^0.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "tsd": "^0.31.1",
     "tsup": "^8.1.0",
     "tsx": "^4.15.7",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "undici": "^6.19.8"
   },
   "type": "module",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ devDependencies:
   typescript:
     specifier: ^5.5.2
     version: 5.5.2
+  undici:
+    specifier: ^6.19.8
+    version: 6.19.8
 
 packages:
 
@@ -3983,6 +3986,11 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /undici@6.19.8:
+    resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
+    engines: {node: '>=18.17'}
     dev: true
 
   /universalify@0.1.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   p-safe:
     specifier: ^1.0.0
     version: 1.0.0
-  undici:
-    specifier: ^6.19.2
-    version: 6.19.2
   zod:
     specifier: ^3.23.8
     version: 3.23.8
@@ -3987,11 +3984,6 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
-
-  /undici@6.19.2:
-    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
-    engines: {node: '>=18.17'}
-    dev: false
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,3 @@
-import { fetch } from 'undici';
-import { setGlobalFetch } from 'zod-request';
-
-setGlobalFetch(fetch);
-
-// -------------------------------
-
 export { Client } from '@/lib/client';
 export { generateCommand } from '@/utils/generate-command';
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,4 +1,3 @@
-import type { RequestInit } from 'undici';
 import { z } from 'zod';
 
 import { Aws } from '@/engine/aws';

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { SafeReturn } from 'p-safe';
-import { RequestInit, Response } from 'undici';
 import type { z } from 'zod';
 import type { RequestSchema as ZodRequestSchema } from 'zod-request';
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -8,7 +8,7 @@ import { VaultError } from '@/errors';
 import { ClientOptionsSchema } from '@/schema';
 
 export type ClientOptions = z.infer<typeof ClientOptionsSchema> & {
-  request?: Partial<RequestInit>;
+  request?: Partial<RequestInit & Record<string, unknown>>;
   fetcher?: Fetcher;
 };
 
@@ -19,7 +19,7 @@ export type RequestSchema = Omit<ZodRequestSchema, 'path' | 'body'> & {
 
 export type Fetcher = (input: any, init: any) => Promise<any>;
 
-export interface ExtendedRequestInit extends RequestInit {
+export interface ExtendedRequestInit extends RequestInit, Record<string, unknown> {
   strictSchema?: boolean;
 }
 

--- a/src/utils/generate-command.ts
+++ b/src/utils/generate-command.ts
@@ -1,7 +1,6 @@
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { SafeReturn, trySafe } from 'p-safe';
-import { fetch, type RequestInit } from 'undici';
 import { z } from 'zod';
 import { generateRequest, ZodRequestInit, ZodResponse } from 'zod-request';
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { expectType } from 'tsd';
-import { ProxyAgent } from 'undici';
+import { fetch, ProxyAgent } from 'undici';
 import { z } from 'zod';
 
 import { Client, generateCommand, VaultError } from '@/index';
@@ -129,6 +129,7 @@ describe('node-vault', () => {
       expect(url).to.be.instanceof(URL);
       expect(url.toString()).to.equal('http://127.0.0.1:8200/v1/secret-path/test');
       used = true;
+      // @ts-expect-error Init type has some missing properties
       return fetch(url, init);
     };
 
@@ -181,6 +182,7 @@ describe('node-vault', () => {
     }
 
     const agent = new ProxyAgent(HTTP_PROXY);
+    vc.fetcher = fetch;
 
     const status = await vc.sealStatus(undefined, { dispatcher: agent });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,7 +1,6 @@
 import { execSync } from 'node:child_process';
 import { accessSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { expect } from 'chai';
 
 import { Client } from '@/index';
 
@@ -25,7 +24,7 @@ export async function createInstance(unsealed: boolean = true): Promise<{
     secret_shares: 1,
     secret_threshold: 1
   });
-  expect(error, error?.message).be.be.undefined;
+  if (error) throw error;
 
   const { keys, root_token } = data!;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
Closes #61 