### PR TITLE
fix: refactor exports structure in `package.json`

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@litehex/node-vault': patch
+---
+
+fix: publish CJS type declarations

--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -2,4 +2,4 @@
 '@litehex/node-vault': patch
 ---
 
-fix: publish CJS type declarations
+fix: refactor exports structure in `package.json`

--- a/package.json
+++ b/package.json
@@ -20,16 +20,21 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "default": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**",
-    "!dist/**/*.d.cts"
+    "dist/**"
   ],
   "scripts": {
     "build": "tsup",

--- a/package.json
+++ b/package.json
@@ -20,19 +20,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "import": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
     }
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**"
   ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist/**",
+    "!dist/**/*.d.cts"
   ],
   "scripts": {
     "build": "tsup",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.cjs"
     }


### PR DESCRIPTION
Closes #116.

`dist/index.d.cts` is built by tsup on every release, but it never reaches
consumers: `files` excluded it explicitly, and the `exports` map carried no
`types` condition at all. A CommonJS project on `moduleResolution: nodenext`
therefore resolved to `dist/index.cjs` with no declarations beside it and
silently typed the whole API as `any`.

The change is limited to `package.json`:

- add `types` to both export conditions, listed first so it is matched before
  the runtime entry
- split the ESM/CJS branches into `import` / `require` so each points at its
  own declaration file
- drop `"!dist/**/*.d.cts"` from `files`

## Verification

`@arethetypeswrong/cli --pack .`, the tool used in the issue:

| | before | after |
| --- | --- | --- |
| node10 | 🟢 | 🟢 |
| node16 (from CJS) | ❌ No types | 🟢 (CJS) |
| node16 (from ESM) | 🟢 (ESM) | 🟢 (ESM) |
| bundler | 🟢 | 🟢 |

I also packed the tarball and installed it into a scratch CommonJS project
with `"module": "nodenext"`. Before the change `tsc --noEmit` reported

```
error TS7016: Could not find a declaration file for module '@litehex/node-vault'.
  '.../dist/index.cjs' implicitly has an 'any' type.
```

and after it exits 0, with `require('@litehex/node-vault')` still resolving to
`dist/index.cjs` at runtime.

`pnpm test` is 41/41 against a local dev Vault, and `typecheck`, `eslint` and
`format:check` are clean.
